### PR TITLE
Fix Value#toJson

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/value/ArrayValue.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/ArrayValue.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 /**
  * The interface {@code ArrayValue} represents MessagePack's Array type.
- * <p/>
+ *
  * MessagePack's Array type can represent sequence of values.
  */
 public interface ArrayValue

--- a/msgpack-core/src/main/java/org/msgpack/value/BinaryValue.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/BinaryValue.java
@@ -17,7 +17,7 @@ package org.msgpack.value;
 
 /**
  * The interface {@code BinaryValue} represents MessagePack's Binary type.
- * <p/>
+ *
  * MessagePack's Binary type can represent a byte array at most 2<sup>64</sup>-1 bytes.
  *
  * @see org.msgpack.value.RawValue

--- a/msgpack-core/src/main/java/org/msgpack/value/BooleanValue.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/BooleanValue.java
@@ -17,7 +17,7 @@ package org.msgpack.value;
 
 /**
  * The interface {@code BooleanValue} represents MessagePack's Boolean type.
- * <p/>
+ *
  * MessagePack's Boolean type can represent {@code true} or {@code false}.
  */
 public interface BooleanValue

--- a/msgpack-core/src/main/java/org/msgpack/value/ExtensionValue.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/ExtensionValue.java
@@ -17,10 +17,10 @@ package org.msgpack.value;
 
 /**
  * The interface {@code ExtensionValue} represents MessagePack's Extension type.
- * <p/>
+ *
  * MessagePack's Extension type can represent represents a tuple of type information and a byte array where type information is an
  * integer whose meaning is defined by applications.
- * <p/>
+ *
  * As the type information, applications can use 0 to 127 as the application-specific types. -1 to -128 is reserved for MessagePack's future extension.
  */
 public interface ExtensionValue

--- a/msgpack-core/src/main/java/org/msgpack/value/FloatValue.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/FloatValue.java
@@ -17,7 +17,7 @@ package org.msgpack.value;
 
 /**
  * The interface {@code FloatValue} represents MessagePack's Float type.
- * <p/>
+ *
  * MessagePack's Float type can represent IEEE 754 double precision floating point numbers including NaN and infinity. This is same with Java's {@code double} type.
  *
  * @see org.msgpack.value.NumberValue

--- a/msgpack-core/src/main/java/org/msgpack/value/IntegerValue.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/IntegerValue.java
@@ -21,7 +21,7 @@ import java.math.BigInteger;
 
 /**
  * The interface {@code IntegerValue} represents MessagePack's Integer type.
- * <p/>
+ *
  * MessagePack's Integer type can represent from -2<sup>63</sup> to 2<sup>64</sup>-1.
  */
 public interface IntegerValue

--- a/msgpack-core/src/main/java/org/msgpack/value/MapValue.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/MapValue.java
@@ -21,7 +21,7 @@ import java.util.Set;
 
 /**
  * The interface {@code ArrayValue} represents MessagePack's Map type.
- * <p/>
+ *
  * MessagePack's Map type can represent sequence of key-value pairs.
  */
 public interface MapValue
@@ -45,9 +45,9 @@ public interface MapValue
 
     /**
      * Returns the key-value pairs as an array of {@code Value}.
-     * <p/>
+     *
      * Odd elements are keys. Next element of an odd element is a value corresponding to the key.
-     * <p/>
+     *
      * For example, if this value represents <code>{"k1": "v1", "k2": "v2"}</code>, this method returns ["k1", "v1", "k2", "v2"].
      */
     Value[] getKeyValueArray();

--- a/msgpack-core/src/main/java/org/msgpack/value/RawValue.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/RawValue.java
@@ -30,14 +30,14 @@ public interface RawValue
 {
     /**
      * Returns the value as {@code byte[]}.
-     * <p/>
+     *
      * This method copies the byte array.
      */
     byte[] asByteArray();
 
     /**
      * Returns the value as {@code ByteBuffer}.
-     * <p/>
+     *
      * Returned ByteBuffer is read-only. See {@code#asReadOnlyBuffer()}.
      * This method doesn't copy the byte array as much as possible.
      */
@@ -45,11 +45,17 @@ public interface RawValue
 
     /**
      * Returns the value as {@code String}.
-     * <p/>
+     *
      * This method throws an exception if the value includes invalid UTF-8 byte sequence.
      *
      * @throws MessageStringCodingException If this value includes invalid UTF-8 byte sequence.
      */
     String asString();
 
+    /**
+     * Returns the value as {@code String}.
+     *
+     * This method replaces an invalid UTF-8 byte sequence with <code>U+FFFD replacement character</code>.
+     */
+    String toString();
 }

--- a/msgpack-core/src/main/java/org/msgpack/value/StringValue.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/StringValue.java
@@ -17,9 +17,9 @@ package org.msgpack.value;
 
 /**
  * The interface {@code StringValue} represents MessagePack's String type.
- * <p/>
+ *
  * MessagePack's String type can represent a UTF-8 string at most 2<sup>64</sup>-1 bytes.
- * <p/>
+ *
  * Note that the value could include invalid byte sequences. {@code asString()} method throws {@code MessageTypeStringCodingException} if the value includes invalid byte sequence. {@code toJson()} method replaces an invalid byte sequence with <code>U+FFFD replacement character</code>.
  *
  * @see org.msgpack.value.RawValue

--- a/msgpack-core/src/main/java/org/msgpack/value/Value.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/Value.java
@@ -30,21 +30,21 @@ public interface Value
 {
     /**
      * Returns type of this value.
-     * <p/>
+     *
      * Note that you can't use <code>instanceof</code> to check type of a value because type of a mutable value is variable.
      */
     ValueType getValueType();
 
     /**
      * Returns immutable copy of this value.
-     * <p/>
+     *
      * This method simply returns <code>this</code> without copying the value if this value is already immutable.
      */
     ImmutableValue immutableValue();
 
     /**
      * Returns true if type of this value is Nil.
-     * <p/>
+     *
      * If this method returns true, {@code asNilValue} never throws exceptions.
      * Note that you can't use <code>instanceof</code> or cast <code>((NilValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      */
@@ -52,7 +52,7 @@ public interface Value
 
     /**
      * Returns true if type of this value is Boolean.
-     * <p/>
+     *
      * If this method returns true, {@code asBooleanValue} never throws exceptions.
      * Note that you can't use <code>instanceof</code> or cast <code>((BooleanValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      */
@@ -60,7 +60,7 @@ public interface Value
 
     /**
      * Returns true if type of this value is Integer or Float.
-     * <p/>
+     *
      * If this method returns true, {@code asNumberValue} never throws exceptions.
      * Note that you can't use <code>instanceof</code> or cast <code>((NumberValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      */
@@ -68,7 +68,7 @@ public interface Value
 
     /**
      * Returns true if type of this value is Integer.
-     * <p/>
+     *
      * If this method returns true, {@code asIntegerValue} never throws exceptions.
      * Note that you can't use <code>instanceof</code> or cast <code>((IntegerValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      */
@@ -76,7 +76,7 @@ public interface Value
 
     /**
      * Returns true if type of this value is Float.
-     * <p/>
+     *
      * If this method returns true, {@code asFloatValue} never throws exceptions.
      * Note that you can't use <code>instanceof</code> or cast <code>((FloatValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      */
@@ -84,7 +84,7 @@ public interface Value
 
     /**
      * Returns true if type of this value is String or Binary.
-     * <p/>
+     *
      * If this method returns true, {@code asRawValue} never throws exceptions.
      * Note that you can't use <code>instanceof</code> or cast <code>((RawValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      */
@@ -92,7 +92,7 @@ public interface Value
 
     /**
      * Returns true if type of this value is Binary.
-     * <p/>
+     *
      * If this method returns true, {@code asBinaryValue} never throws exceptions.
      * Note that you can't use <code>instanceof</code> or cast <code>((BinaryValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      */
@@ -100,7 +100,7 @@ public interface Value
 
     /**
      * Returns true if type of this value is String.
-     * <p/>
+     *
      * If this method returns true, {@code asStringValue} never throws exceptions.
      * Note that you can't use <code>instanceof</code> or cast <code>((StringValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      */
@@ -108,7 +108,7 @@ public interface Value
 
     /**
      * Returns true if type of this value is Array.
-     * <p/>
+     *
      * If this method returns true, {@code asArrayValue} never throws exceptions.
      * Note that you can't use <code>instanceof</code> or cast <code>((ArrayValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      */
@@ -116,7 +116,7 @@ public interface Value
 
     /**
      * Returns true if type of this value is Map.
-     * <p/>
+     *
      * If this method returns true, {@code asMapValue} never throws exceptions.
      * Note that you can't use <code>instanceof</code> or cast <code>((MapValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      */
@@ -124,7 +124,7 @@ public interface Value
 
     /**
      * Returns true if type of this an Extension.
-     * <p/>
+     *
      * If this method returns true, {@code asExtensionValue} never throws exceptions.
      * Note that you can't use <code>instanceof</code> or cast <code>((ExtensionValue) thisValue)</code> to check type of a value because
      * type of a mutable value is variable.
@@ -133,7 +133,7 @@ public interface Value
 
     /**
      * Returns the value as {@code NilValue}. Otherwise throws {@code MessageTypeCastException}.
-     * <p/>
+     *
      * Note that you can't use <code>instanceof</code> or cast <code>((NilValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      *
      * @throws MessageTypeCastException If type of this value is not Nil.
@@ -142,7 +142,7 @@ public interface Value
 
     /**
      * Returns the value as {@code BooleanValue}. Otherwise throws {@code MessageTypeCastException}.
-     * <p/>
+     *
      * Note that you can't use <code>instanceof</code> or cast <code>((BooleanValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      *
      * @throws MessageTypeCastException If type of this value is not Boolean.
@@ -151,7 +151,7 @@ public interface Value
 
     /**
      * Returns the value as {@code NumberValue}. Otherwise throws {@code MessageTypeCastException}.
-     * <p/>
+     *
      * Note that you can't use <code>instanceof</code> or cast <code>((NumberValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      *
      * @throws MessageTypeCastException If type of this value is not Integer or Float.
@@ -160,7 +160,7 @@ public interface Value
 
     /**
      * Returns the value as {@code IntegerValue}. Otherwise throws {@code MessageTypeCastException}.
-     * <p/>
+     *
      * Note that you can't use <code>instanceof</code> or cast <code>((IntegerValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      *
      * @throws MessageTypeCastException If type of this value is not Integer.
@@ -169,7 +169,7 @@ public interface Value
 
     /**
      * Returns the value as {@code FloatValue}. Otherwise throws {@code MessageTypeCastException}.
-     * <p/>
+     *
      * Note that you can't use <code>instanceof</code> or cast <code>((FloatValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      *
      * @throws MessageTypeCastException If type of this value is not Float.
@@ -178,7 +178,7 @@ public interface Value
 
     /**
      * Returns the value as {@code RawValue}. Otherwise throws {@code MessageTypeCastException}.
-     * <p/>
+     *
      * Note that you can't use <code>instanceof</code> or cast <code>((RawValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      *
      * @throws MessageTypeCastException If type of this value is not Binary or String.
@@ -187,7 +187,7 @@ public interface Value
 
     /**
      * Returns the value as {@code BinaryValue}. Otherwise throws {@code MessageTypeCastException}.
-     * <p/>
+     *
      * Note that you can't use <code>instanceof</code> or cast <code>((BinaryValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      *
      * @throws MessageTypeCastException If type of this value is not Binary.
@@ -196,7 +196,7 @@ public interface Value
 
     /**
      * Returns the value as {@code StringValue}. Otherwise throws {@code MessageTypeCastException}.
-     * <p/>
+     *
      * Note that you can't use <code>instanceof</code> or cast <code>((StringValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      *
      * @throws MessageTypeCastException If type of this value is not String.
@@ -205,7 +205,7 @@ public interface Value
 
     /**
      * Returns the value as {@code ArrayValue}. Otherwise throws {@code MessageTypeCastException}.
-     * <p/>
+     *
      * Note that you can't use <code>instanceof</code> or cast <code>((ArrayValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      *
      * @throws MessageTypeCastException If type of this value is not Array.
@@ -214,7 +214,7 @@ public interface Value
 
     /**
      * Returns the value as {@code MapValue}. Otherwise throws {@code MessageTypeCastException}.
-     * <p/>
+     *
      * Note that you can't use <code>instanceof</code> or cast <code>((MapValue) thisValue)</code> to check type of a value because type of a mutable value is variable.
      *
      * @throws MessageTypeCastException If type of this value is not Map.
@@ -223,7 +223,7 @@ public interface Value
 
     /**
      * Returns the value as {@code ExtensionValue}. Otherwise throws {@code MessageTypeCastException}.
-     * <p/>
+     *
      * Note that you can't use <code>instanceof</code> or cast <code>((ExtensionValue) thisValue)</code> to check type of a value
      * because type of a mutable value is variable.
      *
@@ -241,17 +241,22 @@ public interface Value
 
     /**
      * Compares this value to the specified object.
-     * <p/>
+     *
      * This method returns {@code true} if type and value are equivalent.
      * If this value is {@code MapValue} or {@code ArrayValue}, this method check equivalence of elements recursively.
      */
     boolean equals(Object obj);
 
     /**
-     * Returns json representation of this Value for debugging purpose.
-     * This output json format is subject to change in future.
-     * Do not write code that depends on the resulting json format.
+     * Returns json representation of this Value.
+     *
+     * Following behavior is not configurable at this release and they might be changed at future releases:
+     *
+     * * if a key of MapValue is not string, the key is converted to a string using toString method.
+     * * NaN and Infinity of DoubleValue are converted to null.
+     * * ExtensionValue is converted to a 2-element array where first element is a number and second element is the data encoded in hex.
+     * * BinaryValue is converted to a string using UTF-8 encoding. Invalid byte sequence is replaced with <code>U+FFFD replacement character</code>.
+     * * Invalid UTF-8 byte sequences in StringValue is replaced with <code>U+FFFD replacement character</code>
      */
     String toJson();
-
 }

--- a/msgpack-core/src/main/java/org/msgpack/value/Variable.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/Variable.java
@@ -195,7 +195,7 @@ public class Variable
         @Override
         public String toString()
         {
-            return toJson();
+            return Variable.this.toString();
         }
     }
 
@@ -683,8 +683,9 @@ public class Variable
             }
         }
 
+        // override for performance optimization
         @Override
-        public String toJson()
+        public String toString()
         {
             byte[] raw = (byte[]) objectValue;
             try {
@@ -1052,13 +1053,13 @@ public class Variable
     @Override
     public String toJson()
     {
-        return immutableValue().toString();  // TODO optimize
+        return immutableValue().toJson();  // TODO optimize
     }
 
     @Override
     public String toString()
     {
-        return toJson();
+        return immutableValue().toString();  // TODO optimize
     }
 
     @Override

--- a/msgpack-core/src/main/java/org/msgpack/value/impl/AbstractImmutableRawValue.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/impl/AbstractImmutableRawValue.java
@@ -79,7 +79,9 @@ public abstract class AbstractImmutableRawValue
     @Override
     public String toJson()
     {
-        return toJson(new StringBuilder()).toString();
+        StringBuilder sb = new StringBuilder();
+        appendJsonString(sb, toString());
+        return sb.toString();
     }
 
     private void decodeString()
@@ -118,12 +120,11 @@ public abstract class AbstractImmutableRawValue
         return decodedStringCache;
     }
 
-    private StringBuilder toJson(StringBuilder sb)
+    static void appendJsonString(StringBuilder sb, String string)
     {
-        String s = toString();
         sb.append("\"");
-        for (int i = 0; i < s.length(); i++) {
-            char ch = s.charAt(i);
+        for (int i = 0; i < string.length(); i++) {
+            char ch = string.charAt(i);
             if (ch < 0x20) {
                 switch (ch) {
                     case '\n':
@@ -169,13 +170,11 @@ public abstract class AbstractImmutableRawValue
             }
         }
         sb.append("\"");
-
-        return sb;
     }
 
     private static final char[] HEX_TABLE = "0123456789ABCDEF".toCharArray();
 
-    private void escapeChar(StringBuilder sb, int ch)
+    private static void escapeChar(StringBuilder sb, int ch)
     {
         sb.append("\\u");
         sb.append(HEX_TABLE[(ch >> 12) & 0x0f]);

--- a/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableArrayValueImpl.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableArrayValueImpl.java
@@ -161,14 +161,10 @@ public class ImmutableArrayValueImpl
     @Override
     public String toJson()
     {
-        return toJson(new StringBuilder()).toString();
-    }
-
-    private StringBuilder toJson(StringBuilder sb)
-    {
         if (array.length == 0) {
-            return sb.append("[]");
+            return "[]";
         }
+        StringBuilder sb = new StringBuilder();
         sb.append("[");
         sb.append(array[0].toJson());
         for (int i = 1; i < array.length; i++) {
@@ -176,13 +172,33 @@ public class ImmutableArrayValueImpl
             sb.append(array[i].toJson());
         }
         sb.append("]");
-        return sb;
+        return sb.toString();
     }
 
     @Override
     public String toString()
     {
-        return toJson();
+        if (array.length == 0) {
+            return "[]";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("[");
+        appendString(sb, array[0]);
+        for (int i = 1; i < array.length; i++) {
+            sb.append(",");
+            appendString(sb, array[i]);
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private static void appendString(StringBuilder sb, Value value)
+    {
+        if (value.isRawValue()) {
+            sb.append(value.toJson());
+        } else {
+            sb.append(value.toString());
+        }
     }
 
     private static class ImmutableArrayValueList

--- a/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableBinaryValueImpl.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableBinaryValueImpl.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 
 /**
  * {@code ImmutableBinaryValueImpl} Implements {@code ImmutableBinaryValue} using a {@code byte[]} field.
- * This implementation caches result of {@code toJson()} and {@code asString()} using a private {@code String} field.
+ * This implementation caches result of {@code toString()} and {@code asString()} using a private {@code String} field.
  *
  * @see org.msgpack.value.StringValue
  */

--- a/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableBooleanValueImpl.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableBooleanValueImpl.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 
 /**
  * {@code ImmutableBooleanValueImpl} Implements {@code ImmutableBooleanValue} using a {@code boolean} field.
- * <p/>
+ *
  * This class is a singleton. {@code ImmutableBooleanValueImpl.trueInstance()} and {@code ImmutableBooleanValueImpl.falseInstance()} are the only instances of this class.
  *
  * @see org.msgpack.value.BooleanValue

--- a/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableDoubleValueImpl.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableDoubleValueImpl.java
@@ -128,12 +128,16 @@ public class ImmutableDoubleValueImpl
     @Override
     public String toJson()
     {
-        return Double.toString(value);
+        if (Double.isNaN(value) || Double.isInfinite(value)) {
+            return "null";
+        } else {
+            return Double.toString(value);
+        }
     }
 
     @Override
     public String toString()
     {
-        return toJson();
+        return Double.toString(value);
     }
 }

--- a/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableExtensionValueImpl.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableExtensionValueImpl.java
@@ -112,6 +112,20 @@ public class ImmutableExtensionValueImpl
     public String toJson()
     {
         StringBuilder sb = new StringBuilder();
+        sb.append('[');
+        sb.append(Byte.toString(type));
+        sb.append(",\"");
+        for (byte e : data) {
+            sb.append(Integer.toString((int) e, 16));
+        }
+        sb.append("\"]");
+        return sb.toString();
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder();
         sb.append('(');
         sb.append(Byte.toString(type));
         sb.append(",0x");
@@ -120,11 +134,5 @@ public class ImmutableExtensionValueImpl
         }
         sb.append(")");
         return sb.toString();
-    }
-
-    @Override
-    public String toString()
-    {
-        return toJson();
     }
 }

--- a/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableMapValueImpl.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableMapValueImpl.java
@@ -148,34 +148,63 @@ public class ImmutableMapValueImpl
     }
 
     @Override
-    public String toString()
-    {
-        return toJson();
-    }
-
-    @Override
     public String toJson()
     {
-        return toJson(new StringBuilder()).toString();
-    }
-
-    private StringBuilder toJson(StringBuilder sb)
-    {
         if (kvs.length == 0) {
-            return sb.append("{}");
+            return "{}";
         }
+        StringBuilder sb = new StringBuilder();
         sb.append("{");
-        sb.append(kvs[0].toJson());
+        appendJsonKey(sb, kvs[0]);
         sb.append(":");
         sb.append(kvs[1].toJson());
         for (int i = 2; i < kvs.length; i += 2) {
             sb.append(",");
-            sb.append(kvs[i].toJson());
+            appendJsonKey(sb, kvs[i]);
             sb.append(":");
             sb.append(kvs[i + 1].toJson());
         }
         sb.append("}");
-        return sb;
+        return sb.toString();
+    }
+
+    private static void appendJsonKey(StringBuilder sb, Value key)
+    {
+        if (key.isRawValue()) {
+            sb.append(key.toJson());
+        } else {
+            ImmutableStringValueImpl.appendJsonString(sb, key.toString());
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        if (kvs.length == 0) {
+            return "{}";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        appendString(sb, kvs[0]);
+        sb.append(":");
+        appendString(sb, kvs[1]);
+        for (int i = 2; i < kvs.length; i += 2) {
+            sb.append(",");
+            appendString(sb, kvs[i]);
+            sb.append(":");
+            appendString(sb, kvs[i + 1]);
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private static void appendString(StringBuilder sb, Value value)
+    {
+        if (value.isRawValue()) {
+            sb.append(value.toJson());
+        } else {
+            sb.append(value.toString());
+        }
     }
 
     private static class ImmutableMapValueMap

--- a/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableNilValueImpl.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableNilValueImpl.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 
 /**
  * {@code ImmutableNilValueImpl} Implements {@code ImmutableNilValue}.
- * <p/>
+ *
  * This class is a singleton. {@code ImmutableNilValueImpl.get()} is the only instances of this class.
  *
  * @see org.msgpack.value.NilValue

--- a/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableStringValueImpl.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableStringValueImpl.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 
 /**
  * {@code ImmutableStringValueImpl} Implements {@code ImmutableStringValue} using a {@code byte[]} field.
- * This implementation caches result of {@code toJson()} and {@code asString()} using a private {@code String} field.
+ * This implementation caches result of {@code toString()} and {@code asString()} using a private {@code String} field.
  *
  * @see org.msgpack.value.StringValue
  */


### PR DESCRIPTION
Value#toJson() is expected to return a valid json since its name. Some
valid MessagePack values are invalid in JSON such as ExtensionValue,
non-string keys in a MapValue, NaN or Infinite.
